### PR TITLE
Curator 객체를 최상단 객체인 Databuter로 이동

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,9 +6,9 @@ client:
 cluster:
   address: 'localhost'
   port: 9090
-  path: 'databuter'
 zooKeeper:
   address: 'localhost'
   port: 2181
+  path: 'databuter'
   baseSleepTimeMs: 1000
   maxRetries: 8

--- a/config.yaml
+++ b/config.yaml
@@ -6,9 +6,9 @@ client:
 cluster:
   address: 'localhost'
   port: 9090
-  coordinator:
-    address: 'localhost'
-    port: 2181
-    path: 'databuter'
-    baseSleepTimeMs: 1000
-    maxRetries: 8
+  path: 'databuter'
+zooKeeper:
+  address: 'localhost'
+  port: 2181
+  baseSleepTimeMs: 1000
+  maxRetries: 8

--- a/config0.yaml
+++ b/config0.yaml
@@ -6,9 +6,9 @@ client:
 cluster:
   address: 'localhost'
   port: 9090
-  path: 'databuter'
 zooKeeper:
   address: 'localhost'
   port: 2181
+  path: 'databuter'
   baseSleepTimeMs: 1000
   maxRetries: 8

--- a/config0.yaml
+++ b/config0.yaml
@@ -6,9 +6,9 @@ client:
 cluster:
   address: 'localhost'
   port: 9090
-  coordinator:
-    address: 'localhost'
-    port: 2181
-    path: 'databuter'
-    baseSleepTimeMs: 1000
-    maxRetries: 8
+  path: 'databuter'
+zooKeeper:
+  address: 'localhost'
+  port: 2181
+  baseSleepTimeMs: 1000
+  maxRetries: 8

--- a/config1.yaml
+++ b/config1.yaml
@@ -6,9 +6,9 @@ client:
 cluster:
   address: 'localhost'
   port: 9091
-  path: 'databuter'
 zooKeeper:
   address: 'localhost'
   port: 2181
+  path: 'databuter'
   baseSleepTimeMs: 1000
   maxRetries: 8

--- a/config1.yaml
+++ b/config1.yaml
@@ -6,9 +6,9 @@ client:
 cluster:
   address: 'localhost'
   port: 9091
-  coordinator:
-    address: 'localhost'
-    port: 2181
-    path: 'databuter'
-    baseSleepTimeMs: 1000
-    maxRetries: 8
+  path: 'databuter'
+zooKeeper:
+  address: 'localhost'
+  port: 2181
+  baseSleepTimeMs: 1000
+  maxRetries: 8

--- a/config2.yaml
+++ b/config2.yaml
@@ -6,9 +6,9 @@ client:
 cluster:
   address: 'localhost'
   port: 9092
-  path: 'databuter'
 zooKeeper:
   address: 'localhost'
   port: 2181
+  path: 'databuter'
   baseSleepTimeMs: 1000
   maxRetries: 8

--- a/config2.yaml
+++ b/config2.yaml
@@ -6,9 +6,9 @@ client:
 cluster:
   address: 'localhost'
   port: 9092
-  coordinator:
-    address: 'localhost'
-    port: 2181
-    path: 'databuter'
-    baseSleepTimeMs: 1000
-    maxRetries: 8
+  path: 'databuter'
+zooKeeper:
+  address: 'localhost'
+  port: 2181
+  baseSleepTimeMs: 1000
+  maxRetries: 8

--- a/src/main/java/databute/databuter/Databuter.java
+++ b/src/main/java/databute/databuter/Databuter.java
@@ -40,6 +40,10 @@ public final class Databuter {
         return instance;
     }
 
+    public CuratorFramework curator() {
+        return curator;
+    }
+
     private void start() throws Exception {
         logger.info("Starting Databuter at {}", Instant.now());
 
@@ -80,7 +84,7 @@ public final class Databuter {
     private void joinCluster() throws ClusterException {
         logger.debug("Joining cluster...");
 
-        cluster = new Cluster(configuration.cluster(), curator, bucketGroup);
+        cluster = new Cluster(configuration.cluster(), bucketGroup);
         cluster.join();
     }
 

--- a/src/main/java/databute/databuter/Databuter.java
+++ b/src/main/java/databute/databuter/Databuter.java
@@ -40,6 +40,10 @@ public final class Databuter {
         return instance;
     }
 
+    public DatabuterConfiguration configuration() {
+        return configuration;
+    }
+
     public CuratorFramework curator() {
         return curator;
     }

--- a/src/main/java/databute/databuter/DatabuterConfiguration.java
+++ b/src/main/java/databute/databuter/DatabuterConfiguration.java
@@ -18,6 +18,9 @@ public class DatabuterConfiguration {
     @JsonProperty("client")
     private ClientConfiguration client;
 
+    @JsonProperty("zooKeeper")
+    private ZooKeeperConfiguration zooKeeper;
+
     @JsonProperty("cluster")
     private ClusterConfiguration cluster;
 
@@ -33,6 +36,10 @@ public class DatabuterConfiguration {
         return client;
     }
 
+    public ZooKeeperConfiguration zooKeeper() {
+        return zooKeeper;
+    }
+
     public ClusterConfiguration cluster() {
         return cluster;
     }
@@ -43,6 +50,7 @@ public class DatabuterConfiguration {
                 .add("bucketMemorySize", bucketMemorySize)
                 .add("gaurdMemorySize", guardMemorySize)
                 .add("client", client)
+                .add("zooKeeper", zooKeeper)
                 .add("cluster", cluster)
                 .toString();
     }

--- a/src/main/java/databute/databuter/DatabuterConfiguration.java
+++ b/src/main/java/databute/databuter/DatabuterConfiguration.java
@@ -24,7 +24,7 @@ public class DatabuterConfiguration {
     public int guardMemorySizeMb() {
         return guardMemorySize * 1024 * 1024;
     }
-  
+
     public int bucketMemorySizeMb() {
         return bucketMemorySize * 1024 * 1024;
     }

--- a/src/main/java/databute/databuter/ZooKeeperConfiguration.java
+++ b/src/main/java/databute/databuter/ZooKeeperConfiguration.java
@@ -1,4 +1,4 @@
-package databute.databuter.cluster.coordinator;
+package databute.databuter;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -6,16 +6,13 @@ import com.google.common.base.MoreObjects;
 import org.apache.commons.lang3.StringUtils;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-public class ClusterCoordinatorConfiguration {
+public class ZooKeeperConfiguration {
 
     @JsonProperty("address")
     private String address;
 
     @JsonProperty("port")
     private int port;
-
-    @JsonProperty("path")
-    private String path;
 
     @JsonProperty("baseSleepTimeMs")
     private int baseSleepTimeMs;
@@ -25,10 +22,6 @@ public class ClusterCoordinatorConfiguration {
 
     public String connectString() {
         return StringUtils.joinWith(":", address, port);
-    }
-
-    public String path() {
-        return path;
     }
 
     public int baseSleepTimeMs() {
@@ -44,7 +37,6 @@ public class ClusterCoordinatorConfiguration {
         return MoreObjects.toStringHelper(this)
                 .add("address", address)
                 .add("port", port)
-                .add("path", path)
                 .add("baseSleepTimeMs", baseSleepTimeMs)
                 .add("maxRetries", maxRetries)
                 .toString();

--- a/src/main/java/databute/databuter/ZooKeeperConfiguration.java
+++ b/src/main/java/databute/databuter/ZooKeeperConfiguration.java
@@ -14,6 +14,9 @@ public class ZooKeeperConfiguration {
     @JsonProperty("port")
     private int port;
 
+    @JsonProperty("path")
+    private String path;
+
     @JsonProperty("baseSleepTimeMs")
     private int baseSleepTimeMs;
 
@@ -22,6 +25,10 @@ public class ZooKeeperConfiguration {
 
     public String connectString() {
         return StringUtils.joinWith(":", address, port);
+    }
+
+    public String path() {
+        return path;
     }
 
     public int baseSleepTimeMs() {
@@ -37,6 +44,7 @@ public class ZooKeeperConfiguration {
         return MoreObjects.toStringHelper(this)
                 .add("address", address)
                 .add("port", port)
+                .add("path", path)
                 .add("baseSleepTimeMs", baseSleepTimeMs)
                 .add("maxRetries", maxRetries)
                 .toString();

--- a/src/main/java/databute/databuter/bucket/Bucket.java
+++ b/src/main/java/databute/databuter/bucket/Bucket.java
@@ -4,13 +4,11 @@ import com.google.common.base.MoreObjects;
 
 import java.util.UUID;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 public class Bucket {
 
     private final String id;
 
-    public Bucket(){
+    public Bucket() {
         this.id = UUID.randomUUID().toString();
     }
 

--- a/src/main/java/databute/databuter/bucket/BucketCoordinator.java
+++ b/src/main/java/databute/databuter/bucket/BucketCoordinator.java
@@ -1,0 +1,77 @@
+package databute.databuter.bucket;
+
+import com.google.gson.Gson;
+import databute.databuter.Databuter;
+import databute.databuter.ZooKeeperConfiguration;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.utils.ZKPaths;
+import org.apache.zookeeper.CreateMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class BucketCoordinator {
+
+    private static final Logger logger = LoggerFactory.getLogger(BucketCoordinator.class);
+
+    private PathChildrenCache cache;
+
+    private final BucketGroup bucketGroup;
+    private final ZooKeeperConfiguration zooKeeperConfiguration;
+
+    public BucketCoordinator(BucketGroup bucketGroup) {
+        this.bucketGroup = checkNotNull(bucketGroup, "bucketGroup");
+        this.zooKeeperConfiguration = Databuter.instance().configuration().zooKeeper();
+    }
+
+    public void start() throws BucketException {
+        registerCacheEvenetListener();
+    }
+
+    private void registerCacheEvenetListener() throws BucketException {
+        final String path = ZKPaths.makePath(zooKeeperConfiguration.path(), "bucket");
+
+        try {
+            cache = new PathChildrenCache(Databuter.instance().curator(), path, true);
+            cache.getListenable().addListener(this::onCacheEvent);
+            cache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
+        } catch (Exception e) {
+            throw new BucketException("Failed to register cache event listener.", e);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private void onCacheEvent(CuratorFramework curator, PathChildrenCacheEvent event) {
+        switch (event.getType()) {
+            case INITIALIZED:
+                onInitialized();
+                break;
+            case CHILD_ADDED:
+                break;
+        }
+    }
+
+    private void onInitialized() {
+        registerBucketGroup();
+    }
+
+    private void registerBucketGroup() {
+        for (Bucket bucket : bucketGroup) {
+            try {
+                final String json = new Gson().toJson(bucket);
+                final String path = ZKPaths.makePath(zooKeeperConfiguration.path(), "bucket", bucket.id());
+                final String createdPath = Databuter.instance().curator()
+                        .create()
+                        .creatingParentContainersIfNeeded()
+                        .withMode(CreateMode.EPHEMERAL)
+                        .forPath(path, json.getBytes());
+                logger.debug("Registered bucket {} at {}", bucket.id(), createdPath);
+            } catch (Exception e) {
+                logger.error("Failed to register bucket group.", e);
+            }
+        }
+    }
+}

--- a/src/main/java/databute/databuter/cluster/Cluster.java
+++ b/src/main/java/databute/databuter/cluster/Cluster.java
@@ -8,6 +8,7 @@ import databute.databuter.cluster.network.ClusterSessionAcceptor;
 import databute.databuter.cluster.node.ClusterNodeConfiguration;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ public class Cluster {
     private ClusterCoordinator coordinator;
 
     private final ClusterConfiguration configuration;
+    private final CuratorFramework curator;
 
     private final String id;
     private final EventLoopGroup loopGroup;
@@ -32,8 +34,9 @@ public class Cluster {
     //TODO(@nono5546):coordinator 리팩토링 때 삭제
     private final BucketGroup bucketGroup;
 
-    public Cluster(ClusterConfiguration configuration, BucketGroup bucketGroup) {
+    public Cluster(ClusterConfiguration configuration, CuratorFramework curator, BucketGroup bucketGroup) {
         this.configuration = checkNotNull(configuration, "configuration");
+        this.curator = checkNotNull(curator, "curator");
         this.id = UUID.randomUUID().toString();
         this.loopGroup = new NioEventLoopGroup();
         this.localNode = new LocalClusterNode(ClusterNodeConfiguration.builder()
@@ -48,6 +51,10 @@ public class Cluster {
 
     public String id() {
         return id;
+    }
+
+    public ClusterConfiguration configuration() {
+        return configuration;
     }
 
     public EventLoopGroup loopGroup() {
@@ -75,7 +82,7 @@ public class Cluster {
     }
 
     private void connectToCoordinator() throws ClusterException {
-        coordinator = new ClusterCoordinator(this, configuration.coordinator(), bucketGroup);
+        coordinator = new ClusterCoordinator(this, curator, bucketGroup);
         coordinator.connect();
     }
 

--- a/src/main/java/databute/databuter/cluster/Cluster.java
+++ b/src/main/java/databute/databuter/cluster/Cluster.java
@@ -8,7 +8,6 @@ import databute.databuter.cluster.network.ClusterSessionAcceptor;
 import databute.databuter.cluster.node.ClusterNodeConfiguration;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
-import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +24,6 @@ public class Cluster {
     private ClusterCoordinator coordinator;
 
     private final ClusterConfiguration configuration;
-    private final CuratorFramework curator;
 
     private final String id;
     private final EventLoopGroup loopGroup;
@@ -34,9 +32,8 @@ public class Cluster {
     //TODO(@nono5546):coordinator 리팩토링 때 삭제
     private final BucketGroup bucketGroup;
 
-    public Cluster(ClusterConfiguration configuration, CuratorFramework curator, BucketGroup bucketGroup) {
+    public Cluster(ClusterConfiguration configuration, BucketGroup bucketGroup) {
         this.configuration = checkNotNull(configuration, "configuration");
-        this.curator = checkNotNull(curator, "curator");
         this.id = UUID.randomUUID().toString();
         this.loopGroup = new NioEventLoopGroup();
         this.localNode = new LocalClusterNode(ClusterNodeConfiguration.builder()
@@ -82,7 +79,7 @@ public class Cluster {
     }
 
     private void connectToCoordinator() throws ClusterException {
-        coordinator = new ClusterCoordinator(this, curator, bucketGroup);
+        coordinator = new ClusterCoordinator(this, bucketGroup);
         coordinator.connect();
     }
 

--- a/src/main/java/databute/databuter/cluster/Cluster.java
+++ b/src/main/java/databute/databuter/cluster/Cluster.java
@@ -1,7 +1,6 @@
 package databute.databuter.cluster;
 
 import com.google.common.base.MoreObjects;
-import databute.databuter.bucket.Bucket;
 import databute.databuter.bucket.BucketGroup;
 import databute.databuter.cluster.coordinator.ClusterCoordinator;
 import databute.databuter.cluster.coordinator.RemoteClusterNodeGroup;

--- a/src/main/java/databute/databuter/cluster/Cluster.java
+++ b/src/main/java/databute/databuter/cluster/Cluster.java
@@ -1,7 +1,6 @@
 package databute.databuter.cluster;
 
 import com.google.common.base.MoreObjects;
-import databute.databuter.bucket.BucketGroup;
 import databute.databuter.cluster.coordinator.ClusterCoordinator;
 import databute.databuter.cluster.coordinator.RemoteClusterNodeGroup;
 import databute.databuter.cluster.network.ClusterSessionAcceptor;
@@ -29,10 +28,8 @@ public class Cluster {
     private final EventLoopGroup loopGroup;
     private final LocalClusterNode localNode;
     private final RemoteClusterNodeGroup remoteNodeGroup;
-    //TODO(@nono5546):coordinator 리팩토링 때 삭제
-    private final BucketGroup bucketGroup;
 
-    public Cluster(ClusterConfiguration configuration, BucketGroup bucketGroup) {
+    public Cluster(ClusterConfiguration configuration) {
         this.configuration = checkNotNull(configuration, "configuration");
         this.id = UUID.randomUUID().toString();
         this.loopGroup = new NioEventLoopGroup();
@@ -42,8 +39,6 @@ public class Cluster {
                 .port(configuration.port())
                 .build());
         this.remoteNodeGroup = new RemoteClusterNodeGroup();
-        //TODO(@nono5546):coordinator 리팩토링 때 삭제
-        this.bucketGroup = bucketGroup;
     }
 
     public String id() {
@@ -79,7 +74,7 @@ public class Cluster {
     }
 
     private void connectToCoordinator() throws ClusterException {
-        coordinator = new ClusterCoordinator(this, bucketGroup);
+        coordinator = new ClusterCoordinator(this);
         coordinator.connect();
     }
 

--- a/src/main/java/databute/databuter/cluster/ClusterConfiguration.java
+++ b/src/main/java/databute/databuter/cluster/ClusterConfiguration.java
@@ -3,7 +3,6 @@ package databute.databuter.cluster;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import databute.databuter.cluster.coordinator.ClusterCoordinatorConfiguration;
 
 import java.net.InetSocketAddress;
 
@@ -16,8 +15,8 @@ public class ClusterConfiguration {
     @JsonProperty("port")
     private int port;
 
-    @JsonProperty("coordinator")
-    private ClusterCoordinatorConfiguration coordinator;
+    @JsonProperty("path")
+    private String path;
 
     public String address() {
         return address;
@@ -31,8 +30,8 @@ public class ClusterConfiguration {
         return new InetSocketAddress(address, port);
     }
 
-    public ClusterCoordinatorConfiguration coordinator() {
-        return coordinator;
+    public String path() {
+        return path;
     }
 
     @Override
@@ -40,7 +39,7 @@ public class ClusterConfiguration {
         return MoreObjects.toStringHelper(this)
                 .add("address", address)
                 .add("port", port)
-                .add("coordinator", coordinator)
+                .add("path", path)
                 .toString();
     }
 }

--- a/src/main/java/databute/databuter/cluster/ClusterConfiguration.java
+++ b/src/main/java/databute/databuter/cluster/ClusterConfiguration.java
@@ -15,9 +15,6 @@ public class ClusterConfiguration {
     @JsonProperty("port")
     private int port;
 
-    @JsonProperty("path")
-    private String path;
-
     public String address() {
         return address;
     }
@@ -30,16 +27,11 @@ public class ClusterConfiguration {
         return new InetSocketAddress(address, port);
     }
 
-    public String path() {
-        return path;
-    }
-
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("address", address)
                 .add("port", port)
-                .add("path", path)
                 .toString();
     }
 }

--- a/src/main/java/databute/databuter/cluster/coordinator/ClusterCoordinator.java
+++ b/src/main/java/databute/databuter/cluster/coordinator/ClusterCoordinator.java
@@ -3,8 +3,6 @@ package databute.databuter.cluster.coordinator;
 import com.google.gson.Gson;
 import databute.databuter.Databuter;
 import databute.databuter.ZooKeeperConfiguration;
-import databute.databuter.bucket.Bucket;
-import databute.databuter.bucket.BucketGroup;
 import databute.databuter.cluster.Cluster;
 import databute.databuter.cluster.ClusterException;
 import databute.databuter.cluster.node.ClusterNodeConfiguration;
@@ -27,12 +25,10 @@ public class ClusterCoordinator {
     private PathChildrenCache cache;
 
     private final Cluster cluster;
-    private final BucketGroup bucketGroup;
     private final ZooKeeperConfiguration zooKeeperConfiguration;
 
-    public ClusterCoordinator(Cluster cluster, BucketGroup bucketGroup) {
+    public ClusterCoordinator(Cluster cluster) {
         this.cluster = checkNotNull(cluster, "cluster");
-        this.bucketGroup = bucketGroup;
         this.zooKeeperConfiguration = Databuter.instance().configuration().zooKeeper();
     }
 
@@ -71,12 +67,6 @@ public class ClusterCoordinator {
         } catch (Exception e) {
             logger.error("Failed to register cluster node.", e);
         }
-
-        try {
-            registerBucketGroup();
-        } catch (Exception e) {
-            logger.error("Failed to register bucket group.", e);
-        }
     }
 
     private void onAdded(ChildData data) {
@@ -105,18 +95,5 @@ public class ClusterCoordinator {
                 .withMode(CreateMode.EPHEMERAL)
                 .forPath(path, json.getBytes());
         logger.debug("Registered cluster node at {}", createdPath);
-    }
-
-    private void registerBucketGroup() throws Exception {
-        for (Bucket bucket : bucketGroup) {
-            final String json = new Gson().toJson(bucket);
-            final String path = ZKPaths.makePath(zooKeeperConfiguration.path(), "bucket", bucket.id());
-            final String createdPath = Databuter.instance().curator()
-                    .create()
-                    .creatingParentContainersIfNeeded()
-                    .withMode(CreateMode.EPHEMERAL)
-                    .forPath(path, json.getBytes());
-            logger.debug("Registered Bucket node at {}", createdPath);
-        }
     }
 }

--- a/src/main/java/databute/databuter/cluster/coordinator/ClusterCoordinator.java
+++ b/src/main/java/databute/databuter/cluster/coordinator/ClusterCoordinator.java
@@ -122,7 +122,7 @@ public class ClusterCoordinator {
                 .forPath(ZKPaths.makePath(configuration.path(), "discovery", cluster.id()), json.getBytes());
         logger.debug("Registered cluster node at {}", path);
     }
-    
+
     private void registerBucketGroup() throws Exception {
         for (Bucket bucket : bucketGroup) {
             final String json = new Gson().toJson(bucket);


### PR DESCRIPTION
`Curator` 객체를 `ClusterCoordinator` 내부에서 생성하여 다른 목적으로 ZooKeeper를 사용해야 하는 경우 어려움이 있어 `Curator` 객체를 `Databuter`로 이동함.

close #46 